### PR TITLE
Fix zkSync payer panic when no receipt is found

### DIFF
--- a/pkg/zksync2/payer.go
+++ b/pkg/zksync2/payer.go
@@ -234,22 +234,20 @@ func (p *Payer) CheckNonceGroup(ctx context.Context, nonceGroup *pipelinedb.Nonc
 	if err != nil {
 		return pipelinedb.TxDropped, []*pipelinedb.TxStatus{}, errs.Wrap(err)
 	}
+
 	status := pipelinedb.TxConfirmed
-	if receipt.Status != types.ReceiptStatusSuccessful {
+	switch {
+	case receipt == nil:
 		status = pipelinedb.TxPending
+	case receipt.Status != types.ReceiptStatusSuccessful:
+		status = pipelinedb.TxFailed
 	}
 
 	return status, []*pipelinedb.TxStatus{
 		{
-			Hash:  nonceGroup.Txs[0].Hash,
-			State: status,
-			Receipt: &types.Receipt{
-				Type:              receipt.Type,
-				TxHash:            receipt.TxHash,
-				GasUsed:           receipt.GasUsed,
-				CumulativeGasUsed: receipt.CumulativeGasUsed,
-				BlockHash:         receipt.BlockHash,
-			},
+			Hash:    nonceGroup.Txs[0].Hash,
+			State:   status,
+			Receipt: receipt,
 		},
 	}, err
 


### PR DESCRIPTION
If the receipt is not found, DefaultProvider.GetTransactionReceipt returns nil. The code does not handle this case and panics checking for the receipt status.

This change adjusts the code to consider the status "pending" if no receipt is found (e.g. receipt is nil), "failed" if the receipt is found with a non-successful status, and "success" otherwise.

It also returns the whole receipt instead of just select fields.