### PR TITLE
Put logs into run directory

### DIFF
--- a/cmd/crybapy/cmd_run.go
+++ b/cmd/crybapy/cmd_run.go
@@ -122,7 +122,9 @@ func doRun(config *runConfig) error {
 		}
 	}
 
-	log, err := openLog(config.DataDir)
+	runDir := filepath.Join(config.DataDir, config.Name)
+
+	log, err := openLog(runDir)
 	if err != nil {
 		return err
 	}
@@ -133,9 +135,7 @@ func doRun(config *runConfig) error {
 		return err
 	}
 
-	runDir := filepath.Join(config.DataDir, config.Name)
 	dbPath := payouts.DBPathFromDir(runDir)
-
 	db, err := pipelinedb.OpenDB(context.Background(), dbPath, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
All of the logs are currently getting dumped into the same `logs` directory at the root data directory, which makes it hard to tell at first glance which log is tied to which run.