### PR TITLE
Checkpoint DB on close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.8.0
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/shopspring/decimal v1.2.0
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/pkg/pipelinedb/db_test.go
+++ b/pkg/pipelinedb/db_test.go
@@ -1,0 +1,67 @@
+package pipelinedb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckpointOnClose(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	assertFiles := func(t *testing.T, want ...string) {
+		t.Helper()
+		assert.Equal(t, want, readDir(t, dir))
+	}
+
+	// Test case order is important. The first test case creates the database
+	// and must execute first.
+
+	t.Run("create read-write", func(t *testing.T) {
+		assertFiles(t)
+
+		db, err := NewDB(context.Background(), dbPath)
+		require.NoError(t, err)
+		assertFiles(t, "test.db", "test.db-shm", "test.db-wal")
+
+		assert.NoError(t, db.Close())
+		assertFiles(t, "test.db")
+	})
+
+	t.Run("open read-write", func(t *testing.T) {
+		assertFiles(t, "test.db")
+
+		db, err := OpenDB(context.Background(), dbPath, false)
+		require.NoError(t, err)
+		assertFiles(t, "test.db", "test.db-shm", "test.db-wal")
+
+		assert.NoError(t, db.Close())
+		assertFiles(t, "test.db")
+	})
+
+	t.Run("open read-only", func(t *testing.T) {
+		assertFiles(t, "test.db")
+
+		db, err := OpenDB(context.Background(), dbPath, true)
+		require.NoError(t, err)
+		assertFiles(t, "test.db", "test.db-shm", "test.db-wal")
+
+		assert.NoError(t, db.Close())
+		assertFiles(t, "test.db")
+	})
+}
+
+func readDir(t *testing.T, dir string) []string {
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}


### PR DESCRIPTION
Doing so safely removes the WAL and SHM files.

Also changed the "readonly" database to just "query_only" so that checkpointing still works.