### PR TITLE
Use logger with rich context with payer

### DIFF
--- a/cmd/crybapy/factory_payer.go
+++ b/cmd/crybapy/factory_payer.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"context"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/spf13/cobra"
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
-	"math/big"
+
 	"storj.io/crypto-batch-payment/pkg/eth"
 	"storj.io/crypto-batch-payment/pkg/payer"
 	"storj.io/crypto-batch-payment/pkg/storjtoken"
@@ -149,7 +151,6 @@ func CreatePayer(ctx context.Context, log *zap.Logger, config PayerConfig, nodeA
 		defer client.Close()
 
 		paymentPayer, err = eth.NewEthPayer(ctx,
-			log,
 			client,
 			contractAddress,
 			owner,
@@ -164,7 +165,6 @@ func CreatePayer(ctx context.Context, log *zap.Logger, config PayerConfig, nodeA
 	case payer.ZkSync:
 		paymentPayer, err = zksync.NewPayer(
 			ctx,
-			log,
 			nodeAddress,
 			spenderKey,
 			int(chainID.Int64()),
@@ -176,7 +176,6 @@ func CreatePayer(ctx context.Context, log *zap.Logger, config PayerConfig, nodeA
 	case payer.ZkWithdraw:
 		paymentPayer, err = zksync.NewPayer(
 			ctx,
-			log,
 			nodeAddress,
 			spenderKey,
 			int(chainID.Int64()),
@@ -194,7 +193,6 @@ func CreatePayer(ctx context.Context, log *zap.Logger, config PayerConfig, nodeA
 			paymasterPayload = common.Hex2Bytes(config.PaymasterPayload)
 		}
 		paymentPayer, err = zksync2.NewPayer(
-			log,
 			common.HexToAddress(config.ContractAddress),
 			nodeAddress,
 			spenderKey,
@@ -206,7 +204,7 @@ func CreatePayer(ctx context.Context, log *zap.Logger, config PayerConfig, nodeA
 			return
 		}
 	case payer.Sim:
-		paymentPayer, err = payer.NewSimPayer(log)
+		paymentPayer, err = payer.NewSimPayer()
 		if err != nil {
 			return
 		}

--- a/pkg/payer/payer.go
+++ b/pkg/payer/payer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/shopspring/decimal"
 	"go.uber.org/zap"
+
 	"storj.io/crypto-batch-payment/pkg/pipelinedb"
 )
 
@@ -27,8 +28,8 @@ type Payer interface {
 	// NextNonce queries chain for the next available nonce value.
 	NextNonce(ctx context.Context) (uint64, error)
 
-	// IsPreconditionMet checks if transaction can be initiated. If return is false pipeline will try again after a short sleep.
-	IsPreconditionMet(ctx context.Context) (bool, error)
+	// CheckPreconditions checks if transaction can be initiated. If unmet preconditions are returned then pipeline will try again after a short sleep.
+	CheckPreconditions(ctx context.Context) (unmet []string, err error)
 
 	// GetTokenBalance returns with the available token balance in real value (with decimals)
 	GetTokenBalance(ctx context.Context) (*big.Int, error)
@@ -40,10 +41,10 @@ type Payer interface {
 	CreateRawTransaction(ctx context.Context, log *zap.Logger, payouts []*pipelinedb.Payout, nonce uint64, storjPrice decimal.Decimal) (tx Transaction, from common.Address, err error)
 
 	// SendTransaction submits the transaction created earlier.
-	SendTransaction(ctx context.Context, tx Transaction) error
+	SendTransaction(ctx context.Context, log *zap.Logger, tx Transaction) error
 
 	// CheckNonceGroup returns with the status of the submitted transactions.
-	CheckNonceGroup(ctx context.Context, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error)
+	CheckNonceGroup(ctx context.Context, log *zap.Logger, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error)
 
 	// PrintEstimate prints out additional information about the planned actions.
 	PrintEstimate(ctx context.Context, remaining int64) error

--- a/pkg/payer/sim.go
+++ b/pkg/payer/sim.go
@@ -7,10 +7,10 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/shopspring/decimal"
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
+
 	"storj.io/crypto-batch-payment/pkg/pipelinedb"
 )
 
@@ -20,7 +20,6 @@ var (
 )
 
 type SimPayer struct {
-	log  *zap.Logger
 	from common.Address
 }
 
@@ -29,7 +28,7 @@ func (s *SimPayer) PrintEstimate(ctx context.Context, remaining int64) error {
 	return nil
 }
 
-func NewSimPayer(log *zap.Logger) (*SimPayer, error) {
+func NewSimPayer() (*SimPayer, error) {
 	hash := make([]byte, 20)
 	_, err := rand.Read(hash)
 	if err != nil {
@@ -37,7 +36,6 @@ func NewSimPayer(log *zap.Logger) (*SimPayer, error) {
 	}
 	return &SimPayer{
 		from: common.BytesToAddress(hash),
-		log:  log,
 	}, nil
 }
 
@@ -45,8 +43,8 @@ func (s *SimPayer) NextNonce(ctx context.Context) (uint64, error) {
 	return uint64(0), nil
 }
 
-func (s *SimPayer) IsPreconditionMet(ctx context.Context) (bool, error) {
-	return true, nil
+func (s *SimPayer) CheckPreconditions(ctx context.Context) ([]string, error) {
+	return nil, nil
 }
 
 func (s *SimPayer) GetTokenBalance(ctx context.Context) (*big.Int, error) {
@@ -73,12 +71,12 @@ func (s *SimPayer) CreateRawTransaction(ctx context.Context, log *zap.Logger, pa
 	}, s.from, nil
 }
 
-func (s *SimPayer) SendTransaction(ctx context.Context, tx Transaction) error {
+func (s *SimPayer) SendTransaction(ctx context.Context, log *zap.Logger, tx Transaction) error {
 	log.Info("Sending transaction")
 	return nil
 }
 
-func (s *SimPayer) CheckNonceGroup(ctx context.Context, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error) {
+func (s *SimPayer) CheckNonceGroup(ctx context.Context, log *zap.Logger, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error) {
 	if len(nonceGroup.Txs) != 1 {
 		return pipelinedb.TxFailed, nil, errs.New("noncegroup should have only 1 transaction, not %d", len(nonceGroup.Txs))
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -274,10 +274,16 @@ func (p *Pipeline) checkNonceGroups(ctx context.Context) (bool, error) {
 	failedCount := 0
 checkLoop:
 	for i := range p.nonceGroups {
+		log := p.log.With(zap.Uint64("nonce", p.nonceGroups[i].Nonce), zap.Int64("payout-group-id", p.nonceGroups[i].PayoutGroupID))
+
+		log.Debug("Checking nonce group",
+			zap.Int("txs", len(p.nonceGroups[i].Txs)),
+		)
+
 		var err error
 		var state pipelinedb.TxState
 		var all []*pipelinedb.TxStatus
-		state, all, err = p.payer.CheckNonceGroup(ctx, p.nonceGroups[i], failedCount > 0)
+		state, all, err = p.payer.CheckNonceGroup(ctx, log, p.nonceGroups[i], failedCount > 0)
 		if err != nil {
 			return true, err
 		}
@@ -335,18 +341,18 @@ func (p *Pipeline) sendTransaction(ctx context.Context, payoutGroupID int64, non
 	}
 
 	for {
-		ready, err := p.payer.IsPreconditionMet(ctx)
+		unmet, err := p.payer.CheckPreconditions(ctx)
 		if err != nil {
 			return nil, err
 		}
-		if ready {
+		if len(unmet) == 0 {
 			break
 		}
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-time.After(5 * time.Second):
-			p.log.Info("Precondition is not met, waiting for 5 seconds")
+			p.log.Info("One or more preconditions are not met, waiting for 5 seconds", zap.Strings("unmet", unmet))
 		}
 	}
 
@@ -414,7 +420,7 @@ func (p *Pipeline) sendTransaction(ctx context.Context, payoutGroupID int64, non
 		return nil, err
 	}
 
-	err = p.payer.SendTransaction(ctx, rawTx)
+	err = p.payer.SendTransaction(ctx, txLog, rawTx)
 	return tx, err
 }
 

--- a/pkg/pipeline/pipeline_eth_test.go
+++ b/pkg/pipeline/pipeline_eth_test.go
@@ -866,7 +866,6 @@ func (test *PipelineTest) newPipeline(stepInCh chan chan []*pipelinedb.NonceGrou
 		spenderKey = test.spender.Key
 	}
 	payer, err := eth.NewEthPayer(context.Background(),
-		zaptest.NewLogger(test),
 		test.Client,
 		test.ContractAddress,
 		owner.Address,

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -198,8 +198,8 @@ func (t *TestPayer) NextNonce(ctx context.Context) (uint64, error) {
 	return ret, nil
 }
 
-func (t *TestPayer) IsPreconditionMet(ctx context.Context) (bool, error) {
-	return true, nil
+func (t *TestPayer) CheckPreconditions(ctx context.Context) ([]string, error) {
+	return nil, nil
 }
 
 func (t *TestPayer) GetTokenBalance(ctx context.Context) (*big.Int, error) {
@@ -221,11 +221,11 @@ func (t *TestPayer) CreateRawTransaction(ctx context.Context, log *zap.Logger, p
 
 }
 
-func (t *TestPayer) SendTransaction(ctx context.Context, tx payer.Transaction) error {
+func (t *TestPayer) SendTransaction(ctx context.Context, log *zap.Logger, tx payer.Transaction) error {
 	return t.sendTransactionHandler(ctx, tx)
 }
 
-func (t *TestPayer) CheckNonceGroup(ctx context.Context, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error) {
+func (t *TestPayer) CheckNonceGroup(ctx context.Context, log *zap.Logger, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error) {
 	return t.checkNonceGroupHandler(ctx, nonceGroup, checkOnly)
 }
 

--- a/pkg/zksync2/payer.go
+++ b/pkg/zksync2/payer.go
@@ -26,7 +26,6 @@ import (
 )
 
 type Payer struct {
-	log              *zap.Logger
 	wallet           *zksync2.Wallet
 	zk               *zksync2.DefaultProvider
 	signer           *zksync2.DefaultEthSigner
@@ -38,7 +37,6 @@ type Payer struct {
 }
 
 func NewPayer(
-	logger *zap.Logger,
 	contractAddress common.Address,
 	url string,
 	key *ecdsa.PrivateKey,
@@ -69,7 +67,6 @@ func NewPayer(
 
 	p := &Payer{
 		wallet:           wallet,
-		log:              logger,
 		zk:               zkSyncProvider,
 		signer:           ethereumSigner,
 		contractAddress:  contractAddress,
@@ -90,8 +87,8 @@ func (p *Payer) NextNonce(ctx context.Context) (uint64, error) {
 	return nonce.Uint64(), nil
 }
 
-func (p *Payer) IsPreconditionMet(ctx context.Context) (bool, error) {
-	return true, nil
+func (p *Payer) CheckPreconditions(ctx context.Context) ([]string, error) {
+	return nil, nil
 }
 
 func (p *Payer) GetTokenBalance(ctx context.Context) (*big.Int, error) {
@@ -213,7 +210,7 @@ func (p *Payer) CreateRawTransaction(ctx context.Context, log *zap.Logger, payou
 	}, from, nil
 }
 
-func (p *Payer) SendTransaction(ctx context.Context, tx payer.Transaction) error {
+func (p *Payer) SendTransaction(ctx context.Context, log *zap.Logger, tx payer.Transaction) error {
 	hash, err := p.zk.SendRawTransaction(tx.Raw.([]byte))
 	if err != nil {
 		return err
@@ -224,7 +221,7 @@ func (p *Payer) SendTransaction(ctx context.Context, tx payer.Transaction) error
 	return nil
 }
 
-func (p *Payer) CheckNonceGroup(ctx context.Context, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error) {
+func (p *Payer) CheckNonceGroup(ctx context.Context, log *zap.Logger, nonceGroup *pipelinedb.NonceGroup, checkOnly bool) (pipelinedb.TxState, []*pipelinedb.TxStatus, error) {
 	if len(nonceGroup.Txs) != 1 {
 		return pipelinedb.TxFailed, nil, errs.New("ZkSync2 payer supports only one transaction per nonce group")
 	}


### PR DESCRIPTION
Threads the logger in from the pipeline for payer operations instead of a logger stashed at initialization time. In general, the pipeline logger has some additional logging fields attached that provide better context for the operation taking place.

Also changed IsPreconditionMet to CheckPreconditions, which returns the unmet preconditions for logging.