### PR TITLE
Statically link libzks-crypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.a
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
 .PHONY: all generate binary test lint
 
+CGO_LDFLAGS="-L$(CURDIR) -lm"
+
 all: binary
 
-libzks-crypto.so:
-	wget https://github.com/zksync-sdk/zksync-crypto-c/releases/download/v0.1.2/zks-crypto-x86_64-unknown-linux-gnu.so -O $(CURDIR)/libzks-crypto.so
+libzks-crypto.a:
+	rm -f libzks-crypto.so # remove the dynamic library if it exists
+	wget https://github.com/zksync-sdk/zksync-crypto-c/releases/download/v0.1.2/zks-crypto-x86_64-unknown-linux-gnu.a -O $(CURDIR)/libzks-crypto.a
 
 generate:
 	go generate ./...
 
-binary: libzks-crypto.so
-	LD_LIBRARY_PATH=$(CURDIR) CGO_LDFLAGS=-L$(CURDIR) go build ./cmd/crybapy
+binary: libzks-crypto.a
+	CGO_LDFLAGS=$(CGO_LDFLAGS) go build ./cmd/crybapy
 
-test: libzks-crypto.so
-	LD_LIBRARY_PATH=$(CURDIR) CGO_LDFLAGS=-L$(CURDIR) go test -race ./...
+test: libzks-crypto.a
+	CGO_LDFLAGS=$(CGO_LDFLAGS) go test -race ./...
 
-lint: libzks-crypto.so
-	LD_LIBRARY_PATH=$(CURDIR) CGO_LDFLAGS=-L$(CURDIR) go run honnef.co/go/tools/cmd/staticcheck@2023.1.6 -checks all ./...
-	LD_LIBRARY_PATH=$(CURDIR) CGO_LDFLAGS=-L$(CURDIR) go vet ./...
+lint: libzks-crypto.a
+	CGO_LDFLAGS=$(CGO_LDFLAGS) go run honnef.co/go/tools/cmd/staticcheck@2023.1.6 -checks all ./...
+	CGO_LDFLAGS=$(CGO_LDFLAGS) go vet ./...


### PR DESCRIPTION
Statically links libzks-crypto.a so that libzks-crypto.so doesn't  have to be distributed with the binary. I verified that the transaction key generation functionality that we depend on still works.