### PR TITLE
Prepayouts CSV loading code

### DIFF
--- a/pkg/prepayoutcsv/load.go
+++ b/pkg/prepayoutcsv/load.go
@@ -1,0 +1,155 @@
+// Package prepayoutcsv provides functions for loading prepayout CSV files
+package prepayoutcsv
+
+import (
+	"bytes"
+	"encoding/csv"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/shopspring/decimal"
+	"github.com/zeebo/errs"
+)
+
+const (
+	expectHeader = "address,amount,address-kind,mandatory,sanctioned,bonus"
+)
+
+type Row struct {
+	// Line number in the CSV file
+	Line int
+
+	// Address is the destination address of the payout
+	Address common.Address `csv:"address"`
+
+	// Amount is the payout mount in USD
+	Amount decimal.Decimal `csv:"amount"`
+
+	// Kind is the type of payout (eth, zksync2)
+	Kind string `csv:"address-kind"`
+
+	// Mandatory is whether or not this payout should be issued even if
+	// it falls below the payment threshold.
+	Mandatory bool `csv:"mandatory"`
+
+	// Sanctioned is whether or not the payee is sanctioned. These rows are
+	// skipped when issuing payouts.
+	Sanctioned bool `csv:"sanctioned"`
+
+	// Bonus indicates whether or not this payee qualifies for a bonus.
+	Bonus bool `csv:"bonus"`
+}
+
+func Load(path string) ([]Row, error) {
+	csvBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	return Parse(csvBytes)
+}
+
+func Parse(csvBytes []byte) ([]Row, error) {
+	r := csv.NewReader(bytes.NewReader(csvBytes))
+	r.FieldsPerRecord = -1
+	r.Comment = '#'
+	r.TrimLeadingSpace = true
+
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+
+	const expectFields = 6
+
+	inHeader := true
+	var rows []Row
+	for i, record := range records {
+		// TODO: this isn't quite accurate. It does not accurately count
+		// commented lines and empty lines. We could manually handle commented
+		// lines but the csv package skips empty lines so we might as well have
+		// it handle comments too since the line number will be inaccurate
+		// anyway.
+		line := i + 1
+
+		// first non-empty, non-comment line must be the header
+		if inHeader {
+			inHeader = false
+			header := strings.Join(record, ",")
+			if header != expectHeader {
+				return nil, errs.New("record on line %d: invalid header %q: expected %q", line, header, expectHeader)
+			}
+			continue
+		}
+
+		// wrong number of fields
+		if len(record) != expectFields {
+			return nil, errs.New("record on line %d: expected %d fields but got %d", line, expectFields, len(record))
+		}
+
+		var (
+			addressValue    = record[0]
+			amountValue     = record[1]
+			kindValue       = record[2]
+			mandatoryValue  = record[3]
+			sanctionedValue = record[4]
+			bonusValue      = record[5]
+		)
+
+		// The address field is sometimes empty in the prepayouts CSVs. They
+		// are included in the results for statistics purposes and will be
+		// ignored in a later step in the process.
+		var address common.Address
+		if len(addressValue) > 0 {
+			var ok bool
+			address, ok = parseAddress(addressValue)
+			if !ok {
+				return nil, errs.New("record on line %d: invalid ETH address %q", line, addressValue)
+			}
+		}
+
+		amount, err := decimal.NewFromString(amountValue)
+		if err != nil {
+			return nil, errs.New("record on line %d: invalid amount %q: %v", line, amountValue, err)
+		}
+
+		if kindValue == "" {
+			return nil, errs.New("record on line %d: invalid kind %q: cannot be empty", line, kindValue)
+		}
+
+		mandatory, err := strconv.ParseBool(mandatoryValue)
+		if err != nil {
+			return nil, errs.New(`record on line %d: invalid boolean value %q for "mandatory" column`, line, mandatoryValue)
+		}
+
+		sanctioned, err := strconv.ParseBool(sanctionedValue)
+		if err != nil {
+			return nil, errs.New(`record on line %d: invalid boolean value %q for "sanctioned" column`, line, sanctionedValue)
+		}
+
+		bonus, err := strconv.ParseBool(bonusValue)
+		if err != nil {
+			return nil, errs.New(`record on line %d: invalid boolean value %q for "bonus" column`, line, bonusValue)
+		}
+
+		rows = append(rows, Row{
+			Line:       line,
+			Address:    address,
+			Amount:     amount,
+			Kind:       kindValue,
+			Mandatory:  mandatory,
+			Sanctioned: sanctioned,
+			Bonus:      bonus,
+		})
+	}
+
+	return rows, nil
+}
+
+func parseAddress(s string) (common.Address, bool) {
+	if !common.IsHexAddress(s) {
+		return common.Address{}, false
+	}
+	return common.HexToAddress(s), true
+}

--- a/pkg/prepayoutcsv/load_test.go
+++ b/pkg/prepayoutcsv/load_test.go
@@ -1,0 +1,113 @@
+package prepayoutcsv_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"storj.io/crypto-batch-payment/pkg/prepayoutcsv"
+)
+
+const (
+	header = `address,amount,address-kind,mandatory,sanctioned,bonus`
+)
+
+var (
+	goodCSV = []byte(header + `
+0xDDc423E04E8A5E581F12453117159666E6EC143b,3.055353,eth,true,false,false
+0xD7D8D54F10f2C70e7b0b1dC97B9F2f495D2cBc55,0.169281,zksync,false,true,false
+0xA765936150751a8d54B40565cdca559de1416D16,2.356021,zksync-era,false,false,true
+,0.000000,eth,true,false,false
+`)
+)
+
+func TestParse(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		prepayouts, err := prepayoutcsv.Parse(goodCSV)
+		require.NoError(t, err)
+		require.Equal(t, []prepayoutcsv.Row{
+			{
+				Line:       2,
+				Address:    common.HexToAddress("0xDDc423E04E8A5E581F12453117159666E6EC143b"),
+				Kind:       "eth",
+				Amount:     decimal.RequireFromString("3.055353"),
+				Mandatory:  true,
+				Sanctioned: false,
+				Bonus:      false,
+			},
+			{
+				Line:       3,
+				Address:    common.HexToAddress("0xD7D8D54F10f2C70e7b0b1dC97B9F2f495D2cBc55"),
+				Kind:       "zksync",
+				Amount:     decimal.RequireFromString("0.169281"),
+				Mandatory:  false,
+				Sanctioned: true,
+				Bonus:      false,
+			},
+			{
+				Line:       4,
+				Address:    common.HexToAddress("0xA765936150751a8d54B40565cdca559de1416D16"),
+				Kind:       "zksync-era",
+				Amount:     decimal.RequireFromString("2.356021"),
+				Mandatory:  false,
+				Sanctioned: false,
+				Bonus:      true,
+			},
+			{
+				Line:       5,
+				Address:    common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				Kind:       "eth",
+				Amount:     decimal.RequireFromString("0.000000"),
+				Mandatory:  true,
+				Sanctioned: false,
+				Bonus:      false,
+			},
+		}, prepayouts)
+	})
+
+	t.Run("bad header", func(t *testing.T) {
+		_, err := prepayoutcsv.Parse([]byte("bad,header\nsome,row"))
+		require.EqualError(t, err, `record on line 1: invalid header "bad,header": expected "address,amount,address-kind,mandatory,sanctioned,bonus"`)
+	})
+
+	t.Run("invalid number of fields", func(t *testing.T) {
+		_, err := prepayoutcsv.Parse([]byte(header + "\nsome,row"))
+		require.EqualError(t, err, `record on line 2: expected 6 fields but got 2`)
+	})
+
+	t.Run("invalid field", func(t *testing.T) {
+		testInvalidField := func(t *testing.T, n int, value string, equalErr string) {
+			t.Helper()
+			fields := []string{"0xDDc423E04E8A5E581F12453117159666E6EC143b", "3.055353", "eth", "true", "false", "false"}
+			fields[n] = value
+			_, err := prepayoutcsv.Parse([]byte(header + "\n" + strings.Join(fields, ",")))
+			require.EqualError(t, err, equalErr)
+		}
+
+		t.Run("address", func(t *testing.T) {
+			testInvalidField(t, 0, "not-an-address", `record on line 2: invalid ETH address "not-an-address"`)
+		})
+
+		t.Run("amount", func(t *testing.T) {
+			testInvalidField(t, 1, "not-an-amount", `record on line 2: invalid amount "not-an-amount": can't convert not-an-amount to decimal`)
+		})
+
+		t.Run("kind", func(t *testing.T) {
+			testInvalidField(t, 2, "", `record on line 2: invalid kind "": cannot be empty`)
+		})
+
+		t.Run("mandatory", func(t *testing.T) {
+			testInvalidField(t, 3, "not-bool", `record on line 2: invalid boolean value "not-bool" for "mandatory" column`)
+		})
+
+		t.Run("sanctioned", func(t *testing.T) {
+			testInvalidField(t, 4, "not-bool", `record on line 2: invalid boolean value "not-bool" for "sanctioned" column`)
+		})
+
+		t.Run("bonus", func(t *testing.T) {
+			testInvalidField(t, 5, "not-bool", `record on line 2: invalid boolean value "not-bool" for "bonus" column`)
+		})
+	})
+}


### PR DESCRIPTION
Adds a package to load the prepayouts CSV files. This is an adaptation of the existing `pkg/csv` package.

Future improvements will initialize the payouts using the prepayouts CSVs.