### PR TITLE
Extract receipts writing into own package

### DIFF
--- a/pkg/receipts/buffer.go
+++ b/pkg/receipts/buffer.go
@@ -1,0 +1,36 @@
+package receipts
+
+import (
+	"bytes"
+	"encoding/csv"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/shopspring/decimal"
+	"storj.io/crypto-batch-payment/pkg/payer"
+)
+
+type Buffer struct {
+	buf bytes.Buffer
+	csv *csv.Writer
+}
+
+func (b *Buffer) Emit(wallet common.Address, amount decimal.Decimal, txHash string, mechanism payer.Type) {
+	b.init()
+	b.write(wallet.String(), amount.String(), txHash, mechanism.String())
+}
+
+func (b *Buffer) Finalize() []byte {
+	b.csv.Flush()
+	return b.buf.Bytes()
+}
+
+func (b *Buffer) init() {
+	if b.csv == nil {
+		b.csv = csv.NewWriter(&b.buf)
+		b.write("wallet", "amount", "txhash", "mechanism")
+	}
+}
+
+func (b *Buffer) write(c1, c2, c3, c4 string) {
+	b.csv.Write([]string{c1, c2, c3, c4})
+}

--- a/pkg/receipts/buffer.go
+++ b/pkg/receipts/buffer.go
@@ -32,5 +32,5 @@ func (b *Buffer) init() {
 }
 
 func (b *Buffer) write(c1, c2, c3, c4 string) {
-	b.csv.Write([]string{c1, c2, c3, c4})
+	_ = b.csv.Write([]string{c1, c2, c3, c4})
 }

--- a/pkg/receipts/buffer_test.go
+++ b/pkg/receipts/buffer_test.go
@@ -1,0 +1,29 @@
+package receipts_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"storj.io/crypto-batch-payment/pkg/payer"
+	"storj.io/crypto-batch-payment/pkg/receipts"
+)
+
+func TestBuffer(t *testing.T) {
+	address1 := common.BytesToAddress(bytes.Repeat([]byte{1}, common.AddressLength))
+	address2 := common.BytesToAddress(bytes.Repeat([]byte{2}, common.AddressLength))
+	address3 := common.BytesToAddress(bytes.Repeat([]byte{3}, common.AddressLength))
+
+	var b receipts.Buffer
+	b.Emit(address1, decimal.NewFromInt(1), "hash1", payer.Eth)
+	b.Emit(address2, decimal.NewFromInt(2), "hash2", payer.ZkSync)
+	b.Emit(address3, decimal.NewFromInt(3), "hash3", payer.ZkSyncEra)
+	receipts := b.Finalize()
+	require.Equal(t, `wallet,amount,txhash,mechanism
+0x0101010101010101010101010101010101010101,1,hash1,eth
+0x0202020202020202020202020202020202020202,2,hash2,zksync
+0x0303030303030303030303030303030303030303,3,hash3,zksync-era
+`, string(receipts))
+}


### PR DESCRIPTION
Pull out receipts code into its own package for easier testing and reuse in new pipeline code.