### PR TITLE
Centralize gas cap management

### DIFF
--- a/cmd/crybapy/cmd_payer_balance.go
+++ b/cmd/crybapy/cmd_payer_balance.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -27,12 +28,11 @@ func newPayerBalanceCommand(parentConfig *payerCommandConfig) *cobra.Command {
 }
 
 func doPayerBalance(config *payerBalanceConfig, spenderKeyPath string) error {
-
 	log, err := openConsoleLog()
 	if err != nil {
 		return err
 	}
-	payer, err := CreatePayer(config.Ctx, log, config.PayerConfig, config.NodeAddress, config.ChainID, spenderKeyPath)
+	payer, _, err := CreatePayer(config.Ctx, log, config.PayerConfig, config.NodeAddress, config.ChainID, spenderKeyPath)
 	if err != nil {
 		return err
 	}
@@ -40,11 +40,7 @@ func doPayerBalance(config *payerBalanceConfig, spenderKeyPath string) error {
 	if err != nil {
 		return err
 	}
-	dec, err := payer.GetTokenDecimals(config.Ctx)
-	if err != nil {
-		return err
-	}
 
-	fmt.Println(printToken(balance, dec, ""))
+	fmt.Println(printToken(balance, payer.Decimals(), ""))
 	return nil
 }

--- a/cmd/crybapy/cmd_payer_transfer.go
+++ b/cmd/crybapy/cmd_payer_transfer.go
@@ -14,6 +14,7 @@ import (
 	"storj.io/crypto-batch-payment/pkg/payouts"
 	"storj.io/crypto-batch-payment/pkg/pipeline"
 	"storj.io/crypto-batch-payment/pkg/pipelinedb"
+	"storj.io/crypto-batch-payment/pkg/txparams"
 )
 
 type payerTransferConfig struct {
@@ -63,7 +64,7 @@ func doPayerTransfer(config *payerTransferConfig, spenderKeyPath string) error {
 	}
 
 	fmt.Println("Running ad-hoc payout (single transfer)...")
-	payer, err := CreatePayer(config.Ctx, log, config.PayerConfig, config.NodeAddress, config.ChainID, spenderKeyPath)
+	payer, gasCaps, err := CreatePayer(config.Ctx, log, config.PayerConfig, config.NodeAddress, config.ChainID, spenderKeyPath)
 	if err != nil {
 		return err
 	}
@@ -112,7 +113,7 @@ func doPayerTransfer(config *payerTransferConfig, spenderKeyPath string) error {
 					LastUpdated: time.Now(),
 				}, err
 			}),
-
+			GasCaps:       txparams.FixedGasCaps(gasCaps),
 			PipelineLimit: pipeline.DefaultLimit,
 			TxDelay:       pipeline.DefaultTxDelay,
 			Drain:         false,

--- a/cmd/crybapy/cmd_run.go
+++ b/cmd/crybapy/cmd_run.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"storj.io/crypto-batch-payment/pkg/pipelinedb"
+	"storj.io/crypto-batch-payment/pkg/txparams"
 
 	"github.com/spf13/cobra"
 	"github.com/zeebo/errs"
@@ -113,7 +114,7 @@ func doRun(config *runConfig) error {
 	}
 
 	fmt.Printf("Running %q payout...\n", config.Name)
-	payer, err := CreatePayer(config.Ctx, log, config.PayerConfig, config.NodeAddress, config.ChainID, config.SpenderKeyPath)
+	payer, gasCaps, err := CreatePayer(config.Ctx, log, config.PayerConfig, config.NodeAddress, config.ChainID, config.SpenderKeyPath)
 	if err != nil {
 		return err
 	}
@@ -127,6 +128,7 @@ func doRun(config *runConfig) error {
 
 	payoutsConfig := payouts.Config{
 		Quoter:        quoter,
+		GasCaps:       txparams.FixedGasCaps(gasCaps),
 		PipelineLimit: config.PipelineLimit,
 		TxDelay:       config.TxDelay,
 		Drain:         config.Drain,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"math/big"
 	"os/user"
 	"path/filepath"
 	"testing"
@@ -41,15 +40,12 @@ func TestLoad_Defaults(t *testing.T) {
 			ERC20ContractAddress: common.HexToAddress("0x1111111111111111111111111111111111111111"),
 			ChainID:              0,
 			Owner:                nil,
-			MaxGas:               nil,
-			GasTipCap:            nil,
 		},
 		ZkSyncEra: &config.ZkSyncEra{
 			NodeAddress:          "https://mainnet.era.zksync.io",
 			SpenderKeyPath:       homePath("some.key"),
 			ERC20ContractAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
 			ChainID:              0,
-			MaxFee:               nil,
 			PaymasterAddress:     nil,
 			PaymasterPayload:     nil,
 		},
@@ -76,15 +72,12 @@ func TestLoad_Overrides(t *testing.T) {
 			ERC20ContractAddress: common.HexToAddress("0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e"),
 			ChainID:              12345,
 			Owner:                ptrOf(common.HexToAddress("0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e")),
-			MaxGas:               big.NewInt(80_000_000_000),
-			GasTipCap:            big.NewInt(2_000_000_000),
 		},
 		ZkSyncEra: &config.ZkSyncEra{
 			NodeAddress:          "https://override.test",
 			SpenderKeyPath:       "override",
 			ERC20ContractAddress: common.HexToAddress("0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e"),
 			ChainID:              12345,
-			MaxFee:               big.NewInt(5678),
 			PaymasterAddress:     ptrOf(common.HexToAddress("0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e")),
 			PaymasterPayload:     []byte("\x01\x23"),
 		},

--- a/pkg/config/eth.go
+++ b/pkg/config/eth.go
@@ -24,8 +24,6 @@ type Eth struct {
 	ERC20ContractAddress common.Address  `toml:"erc20_contract_address"`
 	ChainID              int             `toml:"chain_id"`
 	Owner                *common.Address `toml:"owner"`
-	MaxGas               *big.Int        `toml:"max_gas"`
-	GasTipCap            *big.Int        `toml:"gas_tip_cap"`
 }
 
 func (c Eth) NewPayer(ctx context.Context) (_ Payer, err error) {
@@ -41,13 +39,6 @@ func (c Eth) NewPayer(ctx context.Context) (_ Payer, err error) {
 	if c.ChainID == 0 {
 		c.ChainID = defaultEthChainID
 	}
-	if c.MaxGas == nil {
-		c.MaxGas, _ = new(big.Int).SetString(defaultMaxGas, 0)
-	}
-	if c.GasTipCap == nil {
-		c.GasTipCap, _ = new(big.Int).SetString(defaultGasTipCap, 0)
-	}
-
 	spenderKey, spenderAddress, err := loadSpenderKey(string(c.SpenderKeyPath))
 	if err != nil {
 		return nil, err
@@ -74,8 +65,6 @@ func (c Eth) NewPayer(ctx context.Context) (_ Payer, err error) {
 		owner,
 		spenderKey,
 		big.NewInt(int64(c.ChainID)),
-		c.GasTipCap,
-		c.MaxGas,
 	)
 	if err != nil {
 		return nil, errs.Wrap(err)

--- a/pkg/config/testdata/defaults.toml
+++ b/pkg/config/testdata/defaults.toml
@@ -12,14 +12,11 @@ node_address           = "https://someaddress.test"
 spender_key_path       = "~/some.key"
 erc20_contract_address = "0x1111111111111111111111111111111111111111"
 # owner                  = ""
-# max_gas                = "70_000_000_000"
-# gas_tip_cap            = "1_000_000_000"
 
 [zksync-era]
 node_address           = "https://mainnet.era.zksync.io"
 spender_key_path       = "~/some.key"
 erc20_contract_address = "0x2222222222222222222222222222222222222222"
 # chain_id               = 324
-# max_fee                = ""
 # paymaster_address      = ""
 # paymaster_payload      = ""

--- a/pkg/config/testdata/override.toml
+++ b/pkg/config/testdata/override.toml
@@ -13,14 +13,11 @@ spender_key_path       = "override"
 erc20_contract_address = "0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e"
 chain_id               = 12345
 owner                  = "0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e"
-max_gas                = "80_000_000_000"
-gas_tip_cap            = "2_000_000_000"
 
 [zksync-era]
 node_address           = "https://override.test"
 spender_key_path       = "override"
 erc20_contract_address = "0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e"
 chain_id               = 12345
-max_fee                = "5678"
 paymaster_address      = "0xe66652d41EE7e81d3fcAe1dF7F9B9f9411ac835e"
 paymaster_payload      = "0123"

--- a/pkg/config/zksync_era.go
+++ b/pkg/config/zksync_era.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"errors"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -19,7 +18,6 @@ type ZkSyncEra struct {
 	SpenderKeyPath       Path            `toml:"spender_key_path"`
 	ERC20ContractAddress common.Address  `toml:"erc20_contract_address"`
 	ChainID              int             `toml:"chain_id"`
-	MaxFee               *big.Int        `toml:"max_fee"`
 	PaymasterAddress     *common.Address `toml:"paymaster_address"`
 	PaymasterPayload     HexString       `toml:"paymaster_payload"`
 }
@@ -49,8 +47,7 @@ func (c ZkSyncEra) NewPayer(ctx context.Context) (_ Payer, err error) {
 		spenderKey,
 		c.ChainID,
 		c.PaymasterAddress,
-		c.PaymasterPayload,
-		c.MaxFee)
+		c.PaymasterPayload)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/payer/sim.go
+++ b/pkg/payer/sim.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/shopspring/decimal"
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
 
@@ -43,11 +42,15 @@ func (s *SimPayer) String() string {
 	return Sim.String()
 }
 
+func (s *SimPayer) Decimals() int32 {
+	return 8
+}
+
 func (s *SimPayer) NextNonce(ctx context.Context) (uint64, error) {
 	return uint64(0), nil
 }
 
-func (s *SimPayer) CheckPreconditions(ctx context.Context) ([]string, error) {
+func (s *SimPayer) CheckPreconditions(ctx context.Context, params TransactionParams) ([]string, error) {
 	return nil, nil
 }
 
@@ -55,11 +58,7 @@ func (s *SimPayer) GetTokenBalance(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(1000000000000), nil
 }
 
-func (s *SimPayer) GetTokenDecimals(ctx context.Context) (int32, error) {
-	return 8, nil
-}
-
-func (s *SimPayer) CreateRawTransaction(ctx context.Context, log *zap.Logger, payouts []*pipelinedb.Payout, nonce uint64, storjPrice decimal.Decimal) (tx Transaction, from common.Address, err error) {
+func (s *SimPayer) CreateRawTransaction(ctx context.Context, log *zap.Logger, params TransactionParams) (tx Transaction, from common.Address, err error) {
 	hash := make([]byte, 32)
 	_, err = rand.Read(hash)
 	if err != nil {
@@ -68,7 +67,7 @@ func (s *SimPayer) CreateRawTransaction(ctx context.Context, log *zap.Logger, pa
 	txHash := common.BytesToHash(hash).String()
 	return Transaction{
 		Hash:  txHash,
-		Nonce: nonce,
+		Nonce: params.Nonce,
 		Raw: map[string]interface{}{
 			"hash": txHash,
 		},

--- a/pkg/pipeline/pipeline_eth_test.go
+++ b/pkg/pipeline/pipeline_eth_test.go
@@ -16,6 +16,7 @@ import (
 
 	"storj.io/crypto-batch-payment/pkg/eth"
 	"storj.io/crypto-batch-payment/pkg/pipelinedb"
+	"storj.io/crypto-batch-payment/pkg/txparams"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -860,14 +861,13 @@ func (test *PipelineTest) newPipeline(stepInCh chan chan []*pipelinedb.NonceGrou
 		test.ContractAddress,
 		owner.Address,
 		spenderKey,
-		big.NewInt(1337),
-		test.gasTipCap,
-		test.maxGas)
+		big.NewInt(1337))
 	test.R.NoError(err)
 	pipeline, err := New(payer, Config{
 		Log:          zaptest.NewLogger(test),
 		Owner:        owner.Address,
 		Quoter:       test.Quoter,
+		GasCaps:      txparams.FixedGasCaps{GasFeeCap: test.maxGas, GasTipCap: test.gasTipCap},
 		DB:           test.DB,
 		Limit:        test.limit,
 		stepInCh:     stepInCh,

--- a/pkg/txparams/suggestor.go
+++ b/pkg/txparams/suggestor.go
@@ -1,0 +1,26 @@
+package txparams
+
+import (
+	"context"
+	"math/big"
+)
+
+type GasCaps struct {
+	// GasFeeCap is the EIP-1559 max fee. If nil, the payer will determine this
+	// value.
+	GasFeeCap *big.Int
+
+	// GasTipCap is the EIP-1559 priority fee. If nil, the payer will determine
+	// this value.
+	GasTipCap *big.Int
+}
+
+type Getter interface {
+	GetGasCaps(ctx context.Context) (GasCaps, error)
+}
+
+type FixedGasCaps GasCaps
+
+func (f FixedGasCaps) GetGasCaps(ctx context.Context) (GasCaps, error) {
+	return GasCaps(f), nil
+}


### PR DESCRIPTION
This is a preparatory change for using the Infura Gas API to determine these values live as the pipeline progresses.

- Moves gas cap determination, and other common transaction parameters, outside of the payers and into the pipeline.
- Made the payer call to determine decimals return a fixed predetermined amount (shouldn't change).
- Refactored some transaction related logging